### PR TITLE
switch to x11 by default

### DIFF
--- a/org.standardnotes.standardnotes.yml
+++ b/org.standardnotes.standardnotes.yml
@@ -17,8 +17,8 @@ finish-args:
   - --filesystem=xdg-run/keyring
   - --share=ipc
   - --share=network
-  - --socket=wayland
-  - --socket=fallback-x11
+  # Wayland support is blocked by https://github.com/electron/electron/issues/33161
+  - --socket=x11
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --persist=Standard Notes Backups

--- a/start-standardnotes.sh
+++ b/start-standardnotes.sh
@@ -5,8 +5,8 @@ set -oue pipefail
 export FLATPAK_ID="${FLATPAK_ID:-org.standardnotes.standardnotes}"
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 
-# Wayland support can be optionally disabled like so:
-# flatpak override --user --env=USE_WAYLAND=0 org.standardnotes.standardnotes
+# Wayland support can be optionally enabled like so:
+# flatpak override --user --env=USE_WAYLAND=1 org.standardnotes.standardnotes
 declare -i USE_WAYLAND="${USE_WAYLAND:-1}"
 declare -i EXIT_CODE=0
 


### PR DESCRIPTION
Wayland support is blocked by https://github.com/electron/electron/issues/33161

Closes https://github.com/flathub/org.standardnotes.standardnotes/issues/104, closes https://github.com/flathub/org.standardnotes.standardnotes/issues/92

There is a performance penalty. Support for Wayland can be enabled optionally, like so.:
```shell
flatpak override --user --env=USE_WAYLAND=1 org.standardnotes.standardnotes
```