### PR TITLE
Url Updates in description

### DIFF
--- a/org.standardnotes.standardnotes.metainfo.xml
+++ b/org.standardnotes.standardnotes.metainfo.xml
@@ -91,10 +91,10 @@
 
   <launchable type="desktop-id">org.standardnotes.standardnotes.desktop</launchable>
 
-  <url type="homepage">https://standardnotes.org/</url>
-  <url type="bugtracker">https://github.com/standardnotes/desktop/issues/</url>
+  <url type="homepage">https://standardnotes.com</url>
+  <url type="bugtracker">https://github.com/standardnotes/app/issues</url>
   <url type="donation">https://github.com/sponsors/standardnotes</url>
-  <url type="help">https://standardnotes.org/help</url>
+  <url type="help">https://standardnotes.com/help</url>
 
   <content_rating type="oars-1.1"/>
 


### PR DESCRIPTION
Updated The Site Link And The GitHub Repo Issues Link As The Previous Repo Was Archived.