### PR TITLE
chore: update license to CC-BY-NC-SA-4.0

### DIFF
--- a/org.standardnotes.standardnotes.metainfo.xml
+++ b/org.standardnotes.standardnotes.metainfo.xml
@@ -8,7 +8,7 @@
   <developer_name>Standard Notes Ltd.</developer_name>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>AGPL-3.0</project_license>
+  <project_license>CC-BY-NC-SA-4.0</project_license>
 
   <recommends>
     <control>pointing</control>


### PR DESCRIPTION
The upstream has changed their license to CC-BY-NC-SA-4.0: https://github.com/standardnotes/forum/discussions/3196#discussioncomment-6604058